### PR TITLE
Fix "Expression statement is not assignment" linter issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function (chai, utils) {
     );
   });
 
-  utils.addProperty(Assertion.prototype, 'jwt', function () {
+  Assertion.addMethod('jwt', function () {
     const decoded = jwt.decode(this._obj);
 
     this.assert(


### PR DESCRIPTION
Fixes https://github.com/chaijs/chai/issues/41. Without this fix the linter throws a warning: `expression statement is not assignment`.

After my PR is merged you can use this package like this:

```
let val = generateToken(user)
val.should.eventually.be.a.jwt()
```